### PR TITLE
add CircleTimeTable.vue

### DIFF
--- a/components/CircleTimeTable.vue
+++ b/components/CircleTimeTable.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue'
+import { PropType } from 'vue'
 
 export interface TimeTableData {
     label: string;
@@ -17,7 +17,8 @@ export interface TimeTableData {
     end: number;
 }
 
-export default defineComponent({
+import Vue from 'vue'
+export default Vue.extend({
     props: {
         height: { type: Number, default: 500 },
         width: { type: Number, default: 500 },
@@ -27,8 +28,8 @@ export default defineComponent({
         }
     },
     watch: {
-        height(o, n) { this.draw(); },
-        width(o, n) { this.draw(); },
+        height() { this.draw(); },
+        width() { this.draw(); },
         timeTableData() { this.draw(); }, 
     },
     methods: {
@@ -96,9 +97,11 @@ export default defineComponent({
 
                 return {
                     x: Math.cos(radian) * (radius + offset) + pivot,
-                    y: Math.sin(radian) * (radius + offset) + pivot                };
+                    y: Math.sin(radian) * (radius + offset) + pivot
+                };
             }
         },
     }
 })
+
 </script>


### PR DESCRIPTION
Add feature circle time table vue.

This code use Typescript Support Option API.
The project need to import "vue-class-component", maybe i think.
Please check this. and Please update package.json.

the other one you need to check is this code use canvas api.
So its render code didn't working sometime beacause of inappropriate render timing.

![image](https://user-images.githubusercontent.com/33588478/133892772-18283dec-51bf-484d-bbf9-65aa902ebb3a.png)

